### PR TITLE
Fix:  GlobalCooldown Firing when GuildCooldown Enabled on Command

### DIFF
--- a/src/structures/commandOptions/globalCooldown.js
+++ b/src/structures/commandOptions/globalCooldown.js
@@ -1,13 +1,13 @@
 import { EmbedBuilder } from "discord.js";
 
 export const globalCooldownFN = async (client, message, command, interactionType) => {
-    if (!command.guildCooldown || isNaN(command.guildCooldown)) return true;
+    if (!command.globalCooldown || isNaN(command.globalCooldown)) return true;
 
     const dbData = `globalCooldown.${interactionType}.${command.name}.${message.member.id}`;
     const currentTime = Date.now();
     const storedTime = client.cooldownDB?.get(dbData) ?? 0;
 
-    if (Math.floor(currentTime - storedTime) >= command.guildCooldown || !storedTime) {
+    if (Math.floor(currentTime - storedTime) >= command.globalCooldown || !storedTime) {
         client.cooldownDB?.set(dbData, currentTime);
         return true;
     }
@@ -23,7 +23,7 @@ export const globalCooldownFN = async (client, message, command, interactionType
                     iconURL: message.member.user.displayAvatarURL()
                 })
                 .setThumbnail(client.user.displayAvatarURL())
-                .setDescription(`You are currently at cooldown. Please try again in <t:${Math.floor(Math.floor(storedTime + command.guildCooldown) / 1000)}:R>.`)
+                .setDescription(`You are currently at cooldown. Please try again in <t:${Math.floor(Math.floor(storedTime + command.globalCooldown) / 1000)}:R>.`)
             ],
         });
 


### PR DESCRIPTION
Fixed an issue where the GlobalCooldown would fire when the GuildCooldown was triggered.

It seems like some of the properties were left in when the code was duplicated for GlobalCooldowns.